### PR TITLE
占う人の名前の空文字列を禁止とする明確なガイドラインを出す

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/yumemi-inc/fake-fortune-telling",
       "state" : {
-        "revision" : "7a26684c5fe8410f3a8b61634805fcc5b805ff38",
-        "version" : "0.2.4"
+        "revision" : "1e2c65fc10a0e45ac780d5ab9919d2648798c048",
+        "version" : "0.2.5"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
 //        ),
         .package(
             url: "https://github.com/yumemi-inc/fake-fortune-telling",
-            from: "0.2.3"
+            from: "0.2.5"
         ),
     ],
     targets: [

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -48,6 +48,7 @@ components:
       properties:
         name:
           type: string
+          minLength: 1
           maxLength: 127
           description: "Target's name."
           example: "ゆめみん"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: ios-junior-engineer-codecheck-backend
-  version: 1.0.0
+  version: 1.0.1
 servers:
   - url: https://yumemi-ios-junior-engineer-codecheck.app.swift.cloud
 paths:


### PR DESCRIPTION
下記のPRに合わせてAPI仕様書を更新：
https://github.com/yumemi-inc/fake-fortune-telling/pull/13

~~（上記がリリースされたら依存ライブラリーの更新もあるので、リリースされるまでこのPRをWIPとする）~~ 更新した