### PR TITLE
Feature/bump swift openapi runtime

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,4 +21,4 @@ jobs:
           swift-version: ${{ env.SWIFT_VERSION }}
 
       - name: Run tests
-        run: swift test --enable-test-discovery
+        run: swift test

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "b2abcfde15a6668548e5ed090464c6c8f2c9874f53045fadcb1a58229e71a34f",
+  "originHash" : "f2533dd47d608539488e8b9dc25fa21755247ca862e2e37761df84a807ea4cbc",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -204,8 +204,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-openapi-runtime",
       "state" : {
-        "revision" : "76951d77a0609599d2dc233e7e40808a74767c6a",
-        "version" : "1.3.2"
+        "revision" : "9a8291fa2f90cc7296f2393a99bb4824ee34f869",
+        "version" : "1.4.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
             from: "0.2.5"
         ),
         .package(url: "https://github.com/apple/swift-openapi-generator", from: "1.2.1"),
-        .package(url: "https://github.com/apple/swift-openapi-runtime", from: "1.3.2"),
+        .package(url: "https://github.com/apple/swift-openapi-runtime", from: "1.4.0"),
         .package(url: "https://github.com/swift-server/swift-openapi-vapor", from: "1.0.1"),
     ],
     targets: [


### PR DESCRIPTION

- bump swift-openapi-runtime
- '--enable-test-discovery' option is deprecated
